### PR TITLE
Update tox test matrix with py36, django 2.0 and Jinja 2.9 and 2.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,26 @@ was added.
 If you want to use jinja2 templates in older versions of Django, take a look
 at `django-jinja <https://github.com/niwinz/django-jinja>`_.
 
-This library has been tested on Python 2.7, 3.4 and 3.5, Jinja 2.7 and 2.8, and
-Django 1.8, 1.9 and 1.10.
+Supported Python versions:
+
+- Python 2.7
+- Python 3.4
+- Python 3.5
+- Python 3.6
+
+Supported Django versions:
+
+- Django 1.8
+- Django 1.9
+- Django 1.10
+- Django 2.0
+
+Supported Jinja2 versions:
+
+- Jinja 2.7
+- Jinja 2.8
+- Jinja 2.9
+- Jinja 2.10
 
 Usage
 =====

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35}-django{18,19,110}-jinja{27,28}
+envlist = py{27,34,35,36}-django{18,19,110}-jinja{27,28,29,210}, py{35,36}-django{20}-jinja{27,28,29,210}
 
 [testenv]
 deps =
@@ -8,7 +8,10 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django20: Django>=2.0,<2.1
     jinja27: Jinja2>=2.7,<2.8
     jinja28: Jinja2>=2.8,<2.9
+    jinja29: Jinja2>=2.9,<2.10
+    jinja210: Jinja2>=2.10,<2.11
 passenv = PYTHONWARNINGS
 commands = {envpython} tests.py


### PR DESCRIPTION
Update the tox test matrix to include the following versions:

* Python 3.6
* Django 2.0 (only Python >=3.5)
* Jinja 2.9 and 2.10